### PR TITLE
remove redundant lovely patches

### DIFF
--- a/lovely/lancer_fan_club/ppu_alexi_colors.toml
+++ b/lovely/lancer_fan_club/ppu_alexi_colors.toml
@@ -3,40 +3,6 @@ version = "1.0.0"
 dump_lua = true
 priority = -10
 
-# this is a lovely patch instead of a pr so i can gatekeep this until the mod releases :3
-# PotatoPatchUtils.CREDITS.generate_string()
-[[patches]]
-[patches.pattern]
-target = '=[SMODS PotatoPatchUtils "src/credits.lua"]'
-pattern = 'AAAAAAcolours = { dev and dev.colour or G.C.UI.BACKGROUND_WHITE }, scale = 0.27,'
-position = 'at'
-payload = '''
-colours = (dev and dev.colours) or { dev and dev.colour or G.C.UI.BACKGROUND_WHITE }, scale = 0.27,
-text_effect = dev and dev.text_effect or nil, shaders = dev and dev.shaders or nil,
-'''
-match_indent = true
-
-# make team credit page also use dynatext
-# PotatoPatchUtils.CREDITS.create_team_credit_page()
-[[patches]]
-[patches.pattern]
-target = '=[SMODS PotatoPatchUtils "src/credits.lua"]'
-pattern = 'name = name[1] and name[1][1] or {n=G.UIT.T, config={scale = 0.47, colour = member.colour, text = member.name}}'
-position = 'at'
-payload = '''
-if member.always_use_dynatext or member.text_effect or member.shaders then
-    name = {n=G.UIT.O, config = {object = DynaText({
-        string = member.loc and localize({type = 'name_text', key = member.loc, set = 'PotatoPatch'}) or dev.name or 'ERROR',
-        colours = member.colours or { member.colour or G.C.UI.BACKGROUND_WHITE }, scale = 0.47,
-        text_effect = member.text_effect or nil, shaders = member.shaders or nil,
-        silent = true, shadow = false, y_offset = -0.6,
-    })}}
-else
-    name = name[1] and name[1][1] or {n=G.UIT.T, config={scale = 0.47, colour = member.colour, text = member.name}}
-end
-'''
-match_indent = true
-
 # lemniscate tomorrow
 # PotatoPatchUtils.CREDITS.create_team_credit_page
 [[patches]]


### PR DESCRIPTION
These patches were only used to implement changes that are now implemented by [https://github.com/Balatro-Potato-Patch/Potato-Patch-Utils/pull/7](this PotatoPatchUtils PR)