### PR TITLE
make space pods not override eigengrau emptiness background

### DIFF
--- a/content/util-modders/space-manager.lua
+++ b/content/util-modders/space-manager.lua
@@ -134,6 +134,7 @@ end
 
 function manager:calc_bg()
     if not self.handname then return end
+    if SMODS.is_active_blind("bl_worm_lfc_eigengrau", true) then return end
     local conf = {
         seed = 0,
         nebula1 = G.C.CLEAR,


### PR DESCRIPTION
i had previously requested for eigengrau emptiness to override any other custom background while active, feel free to reject this pr though