### PR TITLE
swap the pack generated to a mega pack instead of a jumbo

### DIFF
--- a/content/taxes_back_pain/main.lua
+++ b/content/taxes_back_pain/main.lua
@@ -433,7 +433,7 @@ SMODS.Joker({
                 G.E_MANAGER:add_event(Event({
                     func = function()
                         card:juice_up(0.3, 0.5)
-                        SMODS.add_booster_to_shop("p_worm_module_jumbo_1")
+                        SMODS.add_booster_to_shop("p_worm_module_mega_1")
                     return true
                     end
                 }))


### PR DESCRIPTION
lets spaceship actually have more value in early use for durability modules