### PR TITLE
Changes to SilkTouch to apply tarts to jokers without selling

### DIFF
--- a/Wormhole.json
+++ b/Wormhole.json
@@ -15,5 +15,6 @@
 		"Lovely (>=0.9)",
 		"PotatoPatchUtils (>=1.0.10)"
 	],
+	"conflicts": ["SilkTouch (<1.2)"],
 	"allow_redistribution": true
 }

--- a/content/TeamMeow/spacetarts.lua
+++ b/content/TeamMeow/spacetarts.lua
@@ -1318,3 +1318,41 @@ function Game:update(dt, ...)
 		end
 	end
 end
+
+-- Modify sell area for tarts
+if SilkTouch then
+	local old_condition = SilkTouch.DragTargets.C_sell.drag_condition
+	SilkTouch.DragTarget:take_ownership("C_sell", {
+		drag_condition = function(card)
+			return old_condition(card) and card.ability.set ~= "worm_meow_Spacetart"
+		end
+	}, true)
+	SilkTouch.DragTarget{
+		key = "tart_sell",
+		moveable_t = function()
+			return Moveable{
+				T = {
+					x = G.jokers.T.x,
+					y = G.jokers.T.y + G.jokers.T.h + 0.4,
+					w = G.jokers.T.w,
+					h = G.jokers.T.h + 0.6,
+				}
+			}
+		end,
+		text = function(card)
+			local sell_loc = copy_table(localize('ml_sell_target'))
+			sell_loc[#sell_loc+1] = localize('$')..card.sell_cost_label
+			return sell_loc
+		end,
+		colour = G.C.GOLD,
+		drag_condition = function(card)
+			return card.area and card.area == G.consumeables and card.ability.set == "worm_meow_Spacetart"
+		end,
+		active_check = function(card)
+			return card:can_sell_card()
+		end,
+		release_func = function(card)
+			G.FUNCS.sell_card{config = {ref_table = card}}
+		end,
+	}
+end


### PR DESCRIPTION
The sell area for cards in `G.consumeables` overlaps `G.jokers`, which is not ideal for tarts as you have to drop it on a joker to apply the effect. Doing so with SilkTouch installed will still apply it normally, except it works on top of earning selling dollars, which is a weird exploit.
This PR aims to fix that by excluding tarts from the original area and adding a new one for it right below.
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/9765ba9e-3b5d-42d6-8930-981eb3247db3" />
This position may not be the best, so changes are welcomed.