### PR TITLE
fix crash when trying to call juice up on an info queue

### DIFF
--- a/content/TheLastResort/2_constellation/8_hercules.lua
+++ b/content/TheLastResort/2_constellation/8_hercules.lua
@@ -31,7 +31,9 @@ SMODS.Consumable{
 			end
 		end
 		card.ability.blind = pseudorandom_element(choices, "tlr_const_hercules")
-		card:juice_up()
+		if not card.fake_card then
+			card:juice_up()
+		end
 	end,
 	set_ability = function (self, card, initial, delay_sprites)
 		if card.ability.tier == 4 then


### PR DESCRIPTION
hercules function to reset the blind is getting called when displayed in an info queue, causing a crash